### PR TITLE
Fix build with latest OSO version

### DIFF
--- a/quickstart.go
+++ b/quickstart.go
@@ -73,8 +73,8 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	o, _ := oso.NewOso()
-	o.RegisterClass(reflect.TypeOf(Expense{}))
-	o.RegisterClass(reflect.TypeOf(User("")))
+	o.RegisterClass(reflect.TypeOf(Expense{}), nil)
+	o.RegisterClass(reflect.TypeOf(User("")), nil)
 	o.LoadFile("policy.polar")
 	results, _ := o.QueryStr("hello(x)")
 	for result := range results {


### PR DESCRIPTION
At some point, OSA's `RegisterClass` method added a second argument, a
constructor for the type. This caused the build to fail for quickstart.
Adding nil as the argument works, since the constructor is not used
in this example.

fix #1